### PR TITLE
Remove Duplicate Import of Link from src\v2\components\common\navbar\…

### DIFF
--- a/src/v2/components/common/navbar/index.jsx
+++ b/src/v2/components/common/navbar/index.jsx
@@ -1,10 +1,7 @@
 import React from "react";
 import {Link} from 'react-router-dom';
 import Logo from "../../../assets/common/logo.svg";
-import YoutubeBg from "../../../assets/navbar/youtube-bg.png";
-import YoutubePlay from "../../../assets/navbar/youtube-play.png";
 import MenuIcon from "../../../assets/navbar/menu.png";
-import { Link } from "react-router-dom";
 import styles from "./index.module.css";
 import { navLinks } from "./data";
 import { useState } from "react";


### PR DESCRIPTION
…index.jsx

Remove Duplicate Import of [import { Link } from "react-router-dom";]

from "src\v2\components\common\navbar\index.jsx"

which was causing the following error "Line 7:9:  Parsing error: Identifier 'Link' has already been declared. (7:9)"


also, remove the unused import of [import YoutubeBg from "../../../assets/navbar/youtube-bg.png";]

and 

[import YoutubePlay from "../../../assets/navbar/youtube-play.png";]







<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


<!--Add screen shots of the changed output-->
## Screenshots 
Add all the screenshots which support your changes
