### PR TITLE
ADD: Action to automate labels

### DIFF
--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -13,6 +13,4 @@ feature:
 wip:
   prs:
     # Add labels
-    label:
-      - 'contributor'
-      - 'needs feedback'
+  

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,12 +1,13 @@
 # Configuration for Label Actions - https://github.com/dessant/label-actions
+
+
+
 # The `feature` label is added to issues
 feature:
   issues:
     # Post a comment, `{issue-author}` is an optional placeholder
-    comment: >
-      :wave: @{issue-author}, please use our idea board to request new features.
-    # Close the issue
-    close: true
+    label:
+      - 'feature'
 
 # The `wip` label is added to pull requests
 wip:
@@ -15,5 +16,3 @@ wip:
     label:
       - 'contributor'
       - 'needs feedback'
-
-

--- a/.github/label-actions.yml
+++ b/.github/label-actions.yml
@@ -1,0 +1,19 @@
+# Configuration for Label Actions - https://github.com/dessant/label-actions
+# The `feature` label is added to issues
+feature:
+  issues:
+    # Post a comment, `{issue-author}` is an optional placeholder
+    comment: >
+      :wave: @{issue-author}, please use our idea board to request new features.
+    # Close the issue
+    close: true
+
+# The `wip` label is added to pull requests
+wip:
+  prs:
+    # Add labels
+    label:
+      - 'contributor'
+      - 'needs feedback'
+
+

--- a/.github/workflows/label-actions.yml
+++ b/.github/workflows/label-actions.yml
@@ -1,0 +1,25 @@
+name: 'Label Actions'
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+  pull_request:
+    types: [labeled, unlabeled]
+  discussion:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  discussions: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/label-actions@v3
+        with:
+          github-token: ${{ github.token }}
+          config-path: '.github/label-actions.yml'
+          process-only: ''


### PR DESCRIPTION
Adds a GitHub action to automate labels. 

The configuration needs to be updated. Currently only adds the `feature` label to all issues, and also adds the `contributor` and `needs feedback` labels to all PRs