### PR TITLE
Fixed the issue Wrong route for mentorship button

### DIFF
--- a/src/components/home/about/cards.jsx
+++ b/src/components/home/about/cards.jsx
@@ -25,7 +25,7 @@ const cards = ({ background = 'static' }) => {
 
 export default cards;
 
-const Card = ({ title, description, btnText }) => {
+const Card = ({ title,link, description, btnText }) => {
   return (
     <div className={styles.card} key={title}>
       <h2 className='h1'> {title} </h2>
@@ -34,7 +34,7 @@ const Card = ({ title, description, btnText }) => {
       <ArrowLink
         as={ButtonLink}
         className={styles.btn}
-        href='https://www.youtube.com/@KunalKushwaha/playlists?view=50&sort=dd&shelf_id=3'
+        href={link}
       >
         {btnText}
       </ArrowLink>
@@ -61,7 +61,7 @@ const data = [
     title: 'Mentorship',
     description:
       'We provide FREE hands-on training in various fields of computer science and have an inclusive community focussing on a learn by doing approach.',
-    link: '/#mentorship',
+    link: 'https://github.com/WeMakeDevs/roadmaps',
     btnText: 'View Roadmaps',
   },
 ];


### PR DESCRIPTION
Now the all the card buttons will direct as per the give data named link .

<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue
href was given a direct link of playlist and in const data below link named data is given which was not used 
This PR fixes the following issues:
all the card button given will direct the user as the given data 
like the given issue was that
View Road map button was opening the playlist  
but it should open the road map git hub link.
closes #289

<!-- Write down all the changes made-->
used the data variable link 
removed the link from href and connected to data variable link from data
and last added the road map d=git hub kink in the data 
## Changes proposed

Here comes all the changes proposed through this PR

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
