### PR TITLE
FAQ Section Transition Bug

### DIFF
--- a/src/components/Accordion/AccordionItem.jsx
+++ b/src/components/Accordion/AccordionItem.jsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react';
 import { FaMinus, FaPlus } from 'react-icons/fa';
 
 import './index.css';
@@ -9,6 +10,8 @@ const AccordionItem = ({
   activeItem,
   setActiveItem,
 }) => {
+  const contentEl = useRef();
+
   return (
     <div className='accordion-item'>
       <button
@@ -22,10 +25,17 @@ const AccordionItem = ({
         </div>
       </button>
       <div
+        ref={contentEl}
         className='answer'
-        style={{ display: index === activeItem ? 'block' : 'none' }}
+        style={
+          index === activeItem
+            ? {
+                maxHeight: contentEl.current.scrollHeight,
+              }
+            : { maxHeight: '0px' }
+        }
       >
-        {answer}
+        <div className='active'>{answer}</div>
       </div>
     </div>
   );

--- a/src/components/Accordion/index.css
+++ b/src/components/Accordion/index.css
@@ -22,12 +22,16 @@
   margin-top: 0rem;
 }
 .accordion-item .answer {
-  padding: 24px 12px 24px 12px;
-  background-color: white;
   overflow: hidden;
+  max-height: 0;
   transition: max-height 0.5s ease-out;
   background-color: rgb(41 51 64/1);
   color: rgb(251 250 255/1);
+}
+
+.active {
+  max-height: max-content;
+  padding: 24px 12px 24px 12px;
 }
 
 .accordion-item .icon {


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:

If you see on the FAQ section on the website, transition for answers is not applied. it open's up the answer abruptly and closes abruptly. I have fixed that issue by giving smooth animation to it. 

<!-- Write down all the changes made-->

## Changes proposed

I have added parent div to the previous answer div and added a useRef hook that could calculate the height of the content present in the div and allocate the height to it because this transition can happen smoothly.

<!-- Check all the boxes which are applicable to check the box correctly follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [X] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screenshots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
### Before:
![wmd](https://user-images.githubusercontent.com/52135949/210704256-1939a803-611b-4e46-9170-50a7d55f8a21.gif)

### After
![wmd2](https://user-images.githubusercontent.com/52135949/210704270-65eb2267-6249-4759-a869-b22bc2940ced.gif)
