### PR TITLE
remove node 14.x check from the node action

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:


### PR DESCRIPTION
Signed-off-by: Anurag Pathak <anuragpathak911@gmail.com>

<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

<!-- Write down all the changes made-->

## Changes proposed

The node workflow no longer runs in node 14.x. This should fix the current failure of the node workflow on every pull request.

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
