### PR TITLE
Solved: Clicking on "Partner" button not close the Navbar in mobile view. #445

### DIFF
--- a/src/components/layout/Navbar/index.jsx
+++ b/src/components/layout/Navbar/index.jsx
@@ -89,7 +89,12 @@ const NavigationLinks = ({ style, open, setOpen, links }) => {
           {link.name}
         </HeaderLink>
       ))}
-      <ArrowLink className={styles.cta} as={ButtonLink} href='#partnerwithus'>
+      <ArrowLink
+        className={styles.cta}
+        as={ButtonLink}
+        href='#partnerwithus'
+        onClick={() => setOpen(false)}
+      >
         Partner
       </ArrowLink>
     </nav>


### PR DESCRIPTION
Fixes issue #445: Clicking on the "Partner" button does not close the Navbar in mobile view.  #445 

- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.
