### PR TITLE
[bug] Back To Top Button Overlapping Fixed

### DIFF
--- a/src/components/ScrollToTop/index.module.css
+++ b/src/components/ScrollToTop/index.module.css
@@ -15,7 +15,6 @@
 @media only screen and (max-width: 480px) {
   .btn--image {
     position: fixed;
-    bottom: 30px;
     right: 10px;
     font-size: 3em;
   }

--- a/src/components/layout/Banner/index.module.css
+++ b/src/components/layout/Banner/index.module.css
@@ -47,6 +47,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-shrink: 0;
 }
 
 .hide {


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:

closes #447

<!-- Write down all the changes made-->

## Changes proposed

Here comes all the changes proposed through this PR
- Removed `bottom: 30px` property for mobile screen.
- Added `flex-shrink: 0` property to the `Cross` button icon. 

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

### Before
![colliding](https://user-images.githubusercontent.com/97666287/219937830-87f8af86-9a2e-435a-b22f-319fe2f3a0f4.png)

### After
![fixedcross](https://user-images.githubusercontent.com/97666287/219937840-3f0b7580-f1f5-4bdd-bf03-fdeed2393d46.png)