### PR TITLE
Fixed ScrollToTop clash with Banner close button

### DIFF
--- a/src/components/ScrollToTop/index.module.css
+++ b/src/components/ScrollToTop/index.module.css
@@ -17,5 +17,6 @@
     position: fixed;
     right: 10px;
     font-size: 3em;
+    translate: 0 -3rem;
   }
 }


### PR DESCRIPTION
## Fixes Issue
Overlaying of ScrollToTop over Event banner close button on mobile phones

This PR fixes the following issues:

closes #issue-number
#468

## Changes proposed
- Removed the clash between "ScrollToTop" button and Event banner "Close" button.

Here comes all the changes proposed through this PR
## Check List (Check all the boxes which are applicable)

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots
![WeMakeDevs-ScrollToTop-bug-Fix](https://user-images.githubusercontent.com/83387409/221429657-16882322-c81f-4624-b100-4f0ee11a3c97.png)
