### PR TITLE
Fixed CSS Validation Errors

### DIFF
--- a/src/components/layout/JoinUs/index.module.css
+++ b/src/components/layout/JoinUs/index.module.css
@@ -121,6 +121,6 @@
     flex-direction: row;
   }
   .layout {
-    padding-botom: 6rem;
+    padding-bottom: 6rem;
   }
 }

--- a/src/components/layout/Partner/index.module.css
+++ b/src/components/layout/Partner/index.module.css
@@ -14,7 +14,7 @@
 .btns {
   display: flex;
   place-content: center;
-  flex-wrap: no-wrap;
+  flex-wrap: nowrap;
   gap: 1rem;
 }
 .btns .copy {


### PR DESCRIPTION

## Changes proposed

Found 2 errors in CSS files :- 
1. Property 'padding-botom' doesn't exist. The closest matching property name is 'padding-bottom' inside JoinUs layout.
2. no-wrap is not a 'flex-wrap' value in Partner layout. Instead it is nowrap.

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.


