### PR TITLE
Fixing the overlap of scroll-to-top button

### DIFF
--- a/src/components/ScrollToTop.jsx
+++ b/src/components/ScrollToTop.jsx
@@ -30,8 +30,9 @@ export default function ScrollToTop() {
       onClick={toTop}
       aria-label='Click here to scroll to top'
       className={clsxm(
-        'h1 fixed right-4 bottom-10 z-50 rounded-full bg-base-100 text-primary transition-all duration-300',
-        goToTop ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0'
+        'h1 fixed right-4 bottom-14 z-50 rounded-full bg-base-100 text-primary transition-all duration-300',
+        goToTop ? 'translate-y-0 opacity-100' : 'translate-y-4 opacity-0',
+        'scroll-to-top-mobile'
       )}
     >
       <IoIosArrowDropupCircle />

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -135,3 +135,8 @@
 .main section:first-child {
   background: transparent;
 }
+@media (max-width: 394px) {
+  .scroll-to-top-mobile {
+    bottom: 12px;
+  }
+}


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:
The scroll-to-top button overlaps the banner's close button

closes #504 

<!-- Write down all the changes made-->

## Changes proposed
Moved the scroll-to-top button a little up so that it does not overlaps and also fixed it in the mobile view.

Here comes all the changes proposed through this PR

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
Before:
![image](https://user-images.githubusercontent.com/94478736/229083355-5b693864-69c4-41bd-ba2e-b57b024c5a3f.png)

After:
![image](https://user-images.githubusercontent.com/94478736/229083469-9d8f4318-6a4d-498b-9a5e-65c5f8a5d4b5.png)

Before(mobile-view):
![image](https://user-images.githubusercontent.com/94478736/229083752-d00cfffb-2fee-4675-b292-23919c83fbcb.png)

After(mobile-view):
![image](https://user-images.githubusercontent.com/94478736/229083866-77706c31-fc40-45fa-a669-0d66e19432b7.png)

