### PR TITLE
dom order fix

### DIFF
--- a/src/components/layout/Navbar/index.jsx
+++ b/src/components/layout/Navbar/index.jsx
@@ -31,13 +31,6 @@ const Navbar = ({ links, cta }) => {
             <Logo />
           </UnstyledLink>
 
-          <NavigationLinks
-            style={styles.nav}
-            open={open}
-            setOpen={setOpen}
-            links={links}
-            cta={cta}
-          />
           <button className={styles.menuBtn} onClick={() => setOpen((p) => !p)}>
             <span className='sr-only'>Menu</span>
             <svg
@@ -55,6 +48,14 @@ const Navbar = ({ links, cta }) => {
               />
             </svg>
           </button>
+
+          <NavigationLinks
+            style={styles.nav}
+            open={open}
+            setOpen={setOpen}
+            links={links}
+            cta={cta}
+          />
         </div>
       </header>
 


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:
Mobile Nav Toggle button order, The mobile nav toggle button should come directly before that content it's toggling in the dom order. This is important part of any disclosure pattern so that the next element is what's been toggled

<!-- Write down all the changes made-->
The changes made are in NavBar/index.jsx where the nav toggle button order is changed from after the navigation links to before the navigation links

## Changes proposed

The Mobile Nav toggle button should come before the Navigation links 

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
