### PR TITLE
fix footer webinars link #564

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -114,7 +114,7 @@ const CommunityLinks = [
   },
   { link: '/events', name: 'Events' },
   { link: '/courses', name: 'Courses' },
-  { link: '/webinars', name: 'Webinars' },
+  { link: '/events/webinars', name: 'Webinars' },
   { link: 'https://github.com/WeMakeDevs/roadmaps', name: 'Roadmaps' },
 ];
 


### PR DESCRIPTION


## Fixes Issue

This PR fixes the Issue #564 ( Footer Webinars Link Not Working )

## Changes proposed

Changing the webinars link from "/webinars" to "/events/webinars".

## Screenshots

Webinars Page - 

Before : 
![Screenshot (286)](https://user-images.githubusercontent.com/35597955/232372007-89ed2c54-9735-414d-98fe-171f4758faa5.png)

After:
![Screenshot (287)](https://user-images.githubusercontent.com/35597955/232372027-348ab464-f0cd-4e00-9fb2-f90cef71a6d6.png)
