### PR TITLE
Updating Copyright Name and Year in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Community Classroom
+Copyright (c) 2023 WeMakeDevs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 WeMakeDevs
+Copyright (c) 2022 WeMakeDevs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Changes proposed

Changing name from "Community Classroom" to "WeMakeDevs"
Changing year from 2022 to 2023


<!--Add screen shots of the changed output-->

## Screenshots
![image](https://user-images.githubusercontent.com/42804812/233788908-9d880261-0b28-4c91-8e05-1fd521136a2d.png)

