### PR TITLE
Redirect to twitter with pre-filled text directly instead of copy.

### DIFF
--- a/src/pages/OpenSourceCoursePage.jsx
+++ b/src/pages/OpenSourceCoursePage.jsx
@@ -24,20 +24,25 @@ import OpenSourceHeroImg from '@/assets/courses/opensource.avif';
 
 const OpenSourcePage = ({ content }) => {
   const [tweetId, setTweetId] = useState(opensourcetweet);
-  const [copied, setCopied] = useState(false);
-  const copyHashtag = () => {
-    navigator.clipboard.writeText('#OpenSourceWithKunal');
-    setCopied(true);
-  };
-  useEffect(() => {
-    const timeout = setTimeout(() => {
-      if (copied) setCopied(false);
-    }, 1000);
+  // const [copied, setCopied] = useState(false);
+  // const copyHashtag = () => {
+  //   navigator.clipboard.writeText('#OpenSourceWithKunal');
+  //   setCopied(true);
+  // };
+  // useEffect(() => {
+  //   const timeout = setTimeout(() => {
+  //     if (copied) setCopied(false);
+  //   }, 1000);
 
-    return () => {
-      clearTimeout(timeout);
-    };
-  }, [copied]);
+  //   return () => {
+  //     clearTimeout(timeout);
+  //   };
+  // }, [copied]);
+  
+  const handleClick = () => {
+    const twitterUrl = 'https://twitter.com/intent/tweet?text=%23OpenSourceWithKunal';
+    window.open(twitterUrl, '_blank');
+  };
 
   return (
     <>
@@ -173,7 +178,7 @@ const OpenSourcePage = ({ content }) => {
                   Use{' '}
                   <button
                     className='relative bg-purple-700/50'
-                    onClick={copyHashtag}
+                    onClick={handleClick}
                   >
                     #OpenSourceWithKunal
                     <div

--- a/src/pages/OpenSourceCoursePage.jsx
+++ b/src/pages/OpenSourceCoursePage.jsx
@@ -1,12 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { BsAward } from 'react-icons/bs';
 import { MdOutlineLabelImportant } from 'react-icons/md';
 import {
   VscDebugBreakpointFunction,
   VscDebugBreakpointLog,
 } from 'react-icons/vsc';
-
-import clsxm from '@/lib/utils';
 
 import { opensourcetweet } from '@/content/opensource';
 
@@ -24,23 +22,10 @@ import OpenSourceHeroImg from '@/assets/courses/opensource.avif';
 
 const OpenSourcePage = ({ content }) => {
   const [tweetId, setTweetId] = useState(opensourcetweet);
-  // const [copied, setCopied] = useState(false);
-  // const copyHashtag = () => {
-  //   navigator.clipboard.writeText('#OpenSourceWithKunal');
-  //   setCopied(true);
-  // };
-  // useEffect(() => {
-  //   const timeout = setTimeout(() => {
-  //     if (copied) setCopied(false);
-  //   }, 1000);
 
-  //   return () => {
-  //     clearTimeout(timeout);
-  //   };
-  // }, [copied]);
-  
   const handleClick = () => {
-    const twitterUrl = 'https://twitter.com/intent/tweet?text=%23OpenSourceWithKunal';
+    const twitterUrl =
+      'https://twitter.com/intent/tweet?text=%23OpenSourceWithKunal';
     window.open(twitterUrl, '_blank');
   };
 
@@ -181,15 +166,6 @@ const OpenSourcePage = ({ content }) => {
                     onClick={handleClick}
                   >
                     #OpenSourceWithKunal
-                    <div
-                      className={clsxm(
-                        'pointer-events-none absolute bottom-0 left-1/2 origin-center -translate-x-1/2 -translate-y-[50%] scale-[.85] rounded bg-content px-2 text-xs text-base-100 opacity-0 transition-all duration-300',
-                        copied &&
-                          'translate-y-[50%] -translate-x-1/2 scale-100 opacity-100'
-                      )}
-                    >
-                      Copied Hashtag
-                    </div>
                   </button>{' '}
                   on Twitter and share your journey regularly
                 </span>


### PR DESCRIPTION

A new feature to the existing code to improve user experience when clicking on the "#OpenSourceWithKunal" hashtag. Instead of copying the hashtag, it now redirects the user to Twitter with the hashtag pre-filled in the compose tweet text box. 
No major UI changes only enhances the UX.
## Proposed Changes

- Updated the code in the specified component to include the required functionality.
- Created a new function `handleClick` to handle the button click event and open a new browser window with the Twitter intent URL.
- Modified the button to trigger the `handleClick` function when clicked.





