### PR TITLE
fix: hide "go to top" button when mobile menu is open

### DIFF
--- a/src/components/layout/Backdrop.jsx
+++ b/src/components/layout/Backdrop.jsx
@@ -13,7 +13,7 @@ const Backdrop = ({
   return (
     <div
       className={clsx(
-        'fixed inset-0 z-50 flex items-center justify-center bg-content/20 transition-opacity',
+        'fixed inset-0 z-[51] flex items-center justify-center bg-content/20 transition-opacity',
         [
           isDarkBg && 'bg-content/20',
           isTransparent && 'bg-transparent',


### PR DESCRIPTION
## Changes proposed

- Hide "go to top" button when mobile menu is open by updating the z-index of the `Backdrop` component.

## Check List (Check all the boxes which are applicable)

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

| Before | After |
|:------:|:-----:|
| <img src="https://github.com/WeMakeDevs/wemakedevs/assets/52018183/726c0e1e-29db-4b50-b5f5-2f82477fc2fa" width="300"> | <img src="https://github.com/WeMakeDevs/wemakedevs/assets/52018183/3aa6c47e-ac45-4ce6-8827-f432c3a227a3" width="300"> |