### PR TITLE
Fixed Typo in WeMakeDevs -> Courses -> Open Source, in FAQ section

### DIFF
--- a/src/content/courses/opensource.js
+++ b/src/content/courses/opensource.js
@@ -167,7 +167,7 @@ const OpenSourcePageContent = {
       id: 'FAQ6',
       question: 'How do I find resources to upskill myself in tech stacks?',
       answer:
-        'We the roadmaps repository which contains curated resources for various tech stacks. You can find it at',
+        'We have a roadmaps repository which contains curated resources for various tech stacks. You can find it at',
       link: {
         title: ' roadmaps.',
         href: 'https://github.com/WeMakeDevs/roadmaps',


### PR DESCRIPTION
## Fixes Issue
This PR fixes the following issues:
- Fixes #714 
- In the sentence, `We the roadmaps repository which contains curated resources for various tech stacks. You can find it at roadmaps.`, `We the roadmaps repository ...` seems to be a typo.
So I rectified it to `We have a roadmaps repository ...`

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.