### PR TITLE
change default selection color

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -31,6 +31,16 @@ html {
   scroll-behavior: smooth;
 }
 
+::-moz-selection {
+  color: rgb(var(--primary));
+  background: rgb(var(--content));
+}
+
+::selection {
+  color: rgb(var(--primary));
+  background: rgb(var(--content));
+}
+
 @layer base {
   body {
     background: #141414;


### PR DESCRIPTION
The default text selection color doesn't match the theme color. 

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

## BEFORE

![Default blue selection color](https://github.com/WeMakeDevs/wemakedevs/assets/95426296/c4e5d0e0-2ace-45f4-9100-7c4445f53e0e)
![Default blue selection color](https://github.com/WeMakeDevs/wemakedevs/assets/95426296/9308a59d-c82a-482c-b0f1-729236887077)

## AFTER

![Theme matched selection color](https://github.com/WeMakeDevs/wemakedevs/assets/95426296/b32a25d8-4c4c-4cdc-a9bc-076785d60e96)
![Theme matched selection color](https://github.com/WeMakeDevs/wemakedevs/assets/95426296/5a4aacbe-ebdc-498b-8733-4a1d2bff5454)


