### PR TITLE
fix:Website responsive for small device (footer issue solved)

### DIFF
--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -20,7 +20,7 @@ const Footer = () => {
   return (
     <footer className='bg-base-200 py-24 text-content' id='footer'>
       <div className='layout flex flex-col gap-4'>
-        <div className='mx-auto grid w-full grid-cols-2 justify-between gap-4 py-4 md:grid-cols-4'>
+        <div className='mx-auto grid w-full grid-cols-2 justify-between gap-x-0 gap-y-4 py-4 sm:gap-x-4 md:grid-cols-4'>
           <div>
             <p className='h4 w-fit border-b-4 border-primary pb-1 text-gray-50'>
               Organization


### PR DESCRIPTION
Previously the Gmail ID was out of the container in the iPhone 5 screen (320px width), Now this issue is resolved  

## Fixes #721 

This PR fixes the following issues:
- first, the gmail is now on the screen when the device is small. ex: iPhone 5 (320 px width)

closes #721 

## Changes proposed
I have changed the CSS class of the div that is binding the content, In that I have removed gap-4 which means it is a gap between the grid from both row and column. so, I have changed it to gap-y-4, gap-x-0 default which makes row gap as 1rem and column gap 0. Also I have added a CSS class as "sm:gap-x-4" which means whenever the screen width is minimum 640px then the column gap will also become the 1 rem. 

You can check the screenshots below.


## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

Add all the screenshots that support your changes

![wemakedevs_1](https://github.com/WeMakeDevs/wemakedevs/assets/85230759/021dcd2f-1fb3-4f9f-b6f6-a1b3957a52c3)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
- Style: Adjusted the grid gaps in the `Footer` component for better responsiveness on different screen sizes. The changes ensure that the layout remains consistent and visually appealing across various devices, enhancing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->