### PR TITLE
Redirect to hashnode when the tracks cards on hashnode page is clicked

### DIFF
--- a/src/components/Cards/TrackCard.jsx
+++ b/src/components/Cards/TrackCard.jsx
@@ -1,6 +1,11 @@
 const TrackCard = ({ image, title, description }) => {
   return (
-    <div className='overflow-hidden rounded-2xl bg-content/5 p-4'>
+    <a
+      href='https://hashnode.com/draft/'
+      target='_blank'
+      rel='noreferrer'
+      className='overflow-hidden rounded-2xl bg-content/5 p-4'
+    >
       <img
         src={image}
         className='aspect-[1145/720] w-full rounded-lg object-cover object-center'
@@ -10,7 +15,7 @@ const TrackCard = ({ image, title, description }) => {
         <h3>{title}</h3>
         <p className='mt-2'>{description}</p>
       </div>
-    </div>
+    </a>
   );
 };
 


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #730  -->

## Fixes Issue #730 - Redirect to Hashnode drafts page when the tracks cards is clicked.

This PR fixes the following issues:

closes #730 

<!-- Write down all the changes made-->

## Changes proposed

Here comes all the changes proposed through this PR
- Redirect the user to Hashnode drafts page when the tracks cards are clicked.

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `TrackCard` component with clickable functionality. Users can now click on any part of the `TrackCard` to be redirected to "https://hashnode.com/draft/" in a new browser tab, providing a more intuitive and seamless navigation experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->