### PR TITLE
Change Register button to partner in syncloop

### DIFF
--- a/src/content/Hackathons/syncloop.js
+++ b/src/content/Hackathons/syncloop.js
@@ -11,7 +11,7 @@ import HackthonPageContent from '@/content/Hackathons/ParticularHackathonPageCon
 const SyncloopHackathon = {
   header: HackthonPageContent.header,
   faq: HackthonPageContent.faq,
-  CTA: HackthonPageContent.CTA,
+  // CTA: HackthonPageContent.CTA,
   slug: 'syncloop',
   title: 'Unleash the API Creativity with Syncloop',
   by: 'Powered by Syncloop',

--- a/src/pages/PerticularhackathonPage.jsx
+++ b/src/pages/PerticularhackathonPage.jsx
@@ -10,7 +10,13 @@ import { getDate } from '@/lib/utils';
 
 import SpeakerCard from '@/components/Cards/SpeakerCard';
 import TimeLineCard from '@/components/Cards/TimeLineCard';
-import { ColumnSection, FAQ, Footer, Navbar } from '@/components/layout';
+import {
+  ColumnSection,
+  FAQ,
+  Footer,
+  Navbar,
+  Partner,
+} from '@/components/layout';
 import { ArrowLink, ButtonLink, UnstyledLink } from '@/components/links';
 import ListItem from '@/components/Listitem';
 
@@ -51,8 +57,8 @@ const PerticularhackathonPage = ({ content }) => {
             {getDate(content.to)}
           </div>
           <div className='h2 text-center font-bold'>
-            {/* Winnner announcement: {getDateTime(content.winnerAnnouc)} */}
-            Winnner announcement: {getDate(content.winnerAnnouc)}
+            {/* Winner announcement: {getDateTime(content.winnerAnnouc)} */}
+            Winner announcement: {getDate(content.winnerAnnouc)}
           </div>
 
           <div className='flex flex-col gap-4 md:flex-row'>
@@ -364,6 +370,7 @@ const Layout = ({ content, children }) => {
       <Navbar links={content.header} cta={content.CTA} />
       <main className='main'>
         {children}
+        <Partner />
         <FAQ faq={content.faq} />
       </main>
       <Footer />


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:

closes #issue-number

<!-- Write down all the changes made-->

## Changes proposed

Here comes all the changes proposed through this PR

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

---
**Bug Fix:**
- Corrected a typo in the `PerticularhackathonPage` component, changing "Winnner announcement" to "Winner announcement". This fix improves the user interface by providing accurate information.

**New Feature:**
- Added a new `Partner` component to the layout on the `PerticularhackathonPage`. This feature enhances the user experience by displaying relevant partner information on the hackathon page.

**Refactor:**
- Removed the redundant assignment of `HackthonPageContent.CTA` to the `CTA` property in the `SyncloopHackathon` object. This change simplifies the codebase and improves maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->