### PR TITLE
Update DevOps Observability Webinar date and time

### DIFF
--- a/src/content/Webinars/ObservabilityDevOps.js
+++ b/src/content/Webinars/ObservabilityDevOps.js
@@ -21,7 +21,7 @@ const ObservabilityDevOps = {
     name: 'Register',
     href: '#register',
   },
-  time: '26 September 2023 12:00:00 GMT',
+  time: '29 September 2023 6:00:00 GMT',
   speakers: [
     {
       name: 'Jasper Paul',


### PR DESCRIPTION
<!--Type in all the issues that have been fixed through this pull request ex : #1 -->

## Fixes Issue

This PR fixes the following issues:

closes #issue-number

<!-- Write down all the changes made-->

## Changes proposed

Here comes all the changes proposed through this PR

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [ ] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated the schedule for the `ObservabilityDevOps` webinar. The new date and time is '29 September 2023 6:00:00 GMT'. This change ensures that users have the most accurate information regarding the timing of this event.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->