### PR TITLE
fix:Responsiveness testimonials details

### DIFF
--- a/src/components/Cards/TestimonialCard.jsx
+++ b/src/components/Cards/TestimonialCard.jsx
@@ -1,12 +1,12 @@
 const TestimonialCard = ({ src, description, from }) => {
   return (
-    <div className='mb-10 flex h-full w-full flex-col items-center justify-center rounded-lg border border-content/20 bg-gradient-to-br from-content/0 to-content/10 p-4 py-8 text-center lg:flex-1'>
+    <div className='mb-10 flex h-full w-full max:md:w-72 flex-col items-center justify-center rounded-lg border border-content/20 bg-gradient-to-br from-content/0 to-content/10 p-4 py-8 text-center lg:flex-1'>
       <img
         alt='testimonial'
         className=' mb-2 inline-block h-20 w-20 rounded-full border-2 border-base-100 bg-base-100/10 object-cover object-center'
         src={src}
       />
-      <p className='text-lg'>{description}</p>
+      <p className='text-lg max-md:w-64'>{description}</p>
       <hr className='styled-hr styled-hr--light mx-auto my-4' />
       <h2 className='text-sm font-medium text-content '>{from}</h2>
     </div>

--- a/src/components/Cards/TestimonialCard.jsx
+++ b/src/components/Cards/TestimonialCard.jsx
@@ -1,12 +1,12 @@
 const TestimonialCard = ({ src, description, from }) => {
   return (
-    <div className='mb-10 flex h-full w-full max:md:w-72 flex-col items-center justify-center rounded-lg border border-content/20 bg-gradient-to-br from-content/0 to-content/10 p-4 py-8 text-center lg:flex-1'>
+    <div className='mb-10 flex h-full w-full flex-col items-center justify-center rounded-lg border border-content/20 bg-gradient-to-br from-content/0 to-content/10 p-4 py-8 text-center lg:flex-1'>
       <img
         alt='testimonial'
         className=' mb-2 inline-block h-20 w-20 rounded-full border-2 border-base-100 bg-base-100/10 object-cover object-center'
         src={src}
       />
-      <p className='text-lg md:max-w-64'>{description}</p>
+      <p className='text-lg'>{description}</p>
       <hr className='styled-hr styled-hr--light mx-auto my-4' />
       <h2 className='text-sm font-medium text-content '>{from}</h2>
     </div>

--- a/src/components/Cards/TestimonialCard.jsx
+++ b/src/components/Cards/TestimonialCard.jsx
@@ -6,7 +6,7 @@ const TestimonialCard = ({ src, description, from }) => {
         className=' mb-2 inline-block h-20 w-20 rounded-full border-2 border-base-100 bg-base-100/10 object-cover object-center'
         src={src}
       />
-      <p className='text-lg max-md:w-64'>{description}</p>
+      <p className='text-lg md:max-w-64'>{description}</p>
       <hr className='styled-hr styled-hr--light mx-auto my-4' />
       <h2 className='text-sm font-medium text-content '>{from}</h2>
     </div>

--- a/src/components/layout/Testimonials.jsx
+++ b/src/components/layout/Testimonials.jsx
@@ -32,7 +32,7 @@ const Testimonials = ({
         {tweetId ? (
           <TweetCarousael tweetId={tweetId} setTweetId={setTweetId} />
         ) : (
-          <div className='flex flex-col gap-4'>
+          <div className='flex flex-col gap-4 max-md:w-80'>
             <Carousel
               cols={3}
               rows={1}


### PR DESCRIPTION

## Fixes Issue #828 

closes #828 

## Changes proposed
Now, Testimonials section is fully responsive with above of 320px , check my PR and also merged it

<!-- Check all the boxes which are applicable to check the box correct follow the following conventions-->
<!--
[x] - Correct
[X] - Correct
-->

## Check List (Check all the boxes which are applicable) <!--Follow the above conventions to check the box-->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

<!--Add screen shots of the changed output-->

## Screenshots

Add all the screenshots which support your changes
![Screenshot 2023-11-27 114054](https://github.com/WeMakeDevs/wemakedevs/assets/125847751/b7c69413-a0d1-45e0-96fe-5e5baa57a5a1)
![Screenshot 2023-11-27 114112](https://github.com/WeMakeDevs/wemakedevs/assets/125847751/86e8389a-9514-4d1f-a32a-5c143971a8df)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
	- Improved responsive design for `TestimonialCard` component, ensuring better layout on medium-sized screens.
	- Adjusted width constraints for testimonials to enhance visual presentation across various devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->