### PR TITLE
fix: remove Team and Partners section

### DIFF
--- a/src/components/layout/Navbar/index.jsx
+++ b/src/components/layout/Navbar/index.jsx
@@ -92,14 +92,16 @@ const NavigationLinks = ({ style, open, setOpen, links, cta }) => {
           {link.name}
         </HeaderLink>
       ))}
-      <ArrowLink
-        className={styles.cta}
-        as={ButtonLink}
-        href={cta ? cta.href : '#partnerwithus'}
-        onClick={() => setOpen(false)}
-      >
-        {cta ? cta.name : 'Partner'}
-      </ArrowLink>
+      {cta && (
+        <ArrowLink
+          className={styles.cta}
+          as={ButtonLink}
+          href={cta ? cta.href : '#partnerwithus'}
+          onClick={() => setOpen(false)}
+        >
+          {cta ? cta.name : 'Partner'}
+        </ArrowLink>
+      )}
     </nav>
   );
 };

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -25,12 +25,13 @@ export {
 const Layout = ({ content, children }) => {
   return (
     <>
-      <Navbar links={content.header} cta={content.CTA} />
+      <Navbar links={content.header} />
+      {/* <Navbar links={content.header} cta={content.CTA} /> */}
       <main className='main'>
         {children}
         <JoinUs />
         <Faq faq={content.faq} />
-        <Partner />
+        {/* <Partner /> */}
       </main>
       <Footer />
     </>

--- a/src/pages/HomePage.jsx
+++ b/src/pages/HomePage.jsx
@@ -5,7 +5,7 @@ import {
   Courses,
   Events,
   Hero,
-  Team,
+  // Team,
 } from '@/components/PageComp/HomePage';
 
 import { HomePageContent } from './content';
@@ -19,7 +19,7 @@ const HomePage = () => {
         <Courses />
         <Events />
         <Content />
-        <Team />
+        {/* <Team /> */}
       </Layout>
       <Banner />
     </>

--- a/src/pages/content.js
+++ b/src/pages/content.js
@@ -50,10 +50,10 @@ export const HomePageContent = {
       name: 'Newsroom',
       href: '#content',
     },
-    {
-      name: 'Team',
-      href: '#team',
-    },
+    // {
+    //   name: 'Team',
+    //   href: '#team',
+    // },
     {
       name: 'Join',
       href: '#join',


### PR DESCRIPTION
Add conditional logic for displaying CTA in navbar 
remove CTA from the navbar
remove Team section
remove Team from the navbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the Navbar to conditionally render the CTA link, ensuring it only displays when applicable.
	- Removed the `cta` prop from the `Layout` component affecting the Navbar and Partner component display.
	- Temporarily disabled the 'Team' section on the HomePage for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->